### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,41 @@ TWAMP client for go
 ## Client Library Synopsis
 
 ```
-c := client.NewClient()
-connection, err := c.Connect("10.1.1.200:862")
-if err != nil {
-	log.Fatal(err)
-}
+	c := twamp.NewClient()
+	connection, err := c.Connect("10.1.1.200:862")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-session, err := connection.CreateSession(
-	twamp.TwampSessionConfig{
-		Port:    6666,
-		Timeout: 1,
-		Padding: 42,
-		TOS:     twamp.EF,
+	session, err := connection.CreateSession(
+		twamp.TwampSessionConfig{
+			ReceiverPort: 6666,
+			SenderPort:   6666,
+			Timeout:      1,
+			Padding:      100,
+			TOS:          twamp.EF,
 		},
 	)
-if err != nil {
-	log.Fatal(err)
-}
+	if err != nil {
+		log.Fatal(err)
+	}
 
-test, err := session.CreateTest()
-if err != nil {
-	log.Fatal(err)
-}
+	test, err := session.CreateTest()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-results := test.RunX(count)
+	count := 2000
+	results := test.RunX(count, func(result *twamp.TwampResults) {
+		fmt.Printf("%.2f  \r", float64(result.SenderSeqNum)/float64(count)*100.0)
+	})
+	if err != nil {
+		log.Fatal("%v", err)
+	}
 
-session.Stop()
-connection.Close()
+	log.Printf("Stat: %+v\n", *results.Stat)
+	session.Stop()
+	connection.Close()
 ```
 
 ## TWAMP ping command line utility

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 )
 
 /*
@@ -31,7 +32,7 @@ func NewClient() *TwampClient {
 
 func (c *TwampClient) Connect(hostname string) (*TwampConnection, error) {
 	// connect to remote host
-	conn, err := net.Dial("tcp", hostname)
+	conn, err := net.DialTimeout("tcp", hostname, time.Second*5)
 	if err != nil {
 		return nil, err
 	}

--- a/connection.go
+++ b/connection.go
@@ -85,11 +85,24 @@ type TwampServerStart struct {
 }
 
 type TwampSessionConfig struct {
-	Port       int
-	SenderPort int
-	Padding    int
-	Timeout    int
-	TOS        int
+	// According to RFC 4656, if Conf-Receiver is not set, Receiver Port
+	// is the UDP port OWAMP-Test to which packets are
+	// requested to be sent.
+	ReceiverPort	int
+	// According to RFC 4656, if Conf-Sender is not set, Sender Port is the
+	// UDP port from which OWAMP-Test packets will be sent.
+	SenderPort 		int
+	// According to RFC 4656, Padding length is the number of octets to be
+	// appended to the normal OWAMP-Test packet (see more on
+	// padding in discussion of OWAMP-Test).
+	Padding    		int
+	// According to RFC 4656, Timeout (or a loss threshold) is an interval of time
+	// (expressed as a timestamp). A packet belonging to the test session
+	// that is being set up by the current Request-Session command will
+	// be considered lost if it is not received during Timeout seconds
+	// after it is sent.
+	Timeout    		int
+	TOS        		int
 }
 
 func (c *TwampConnection) getTwampServerStartMessage() (*TwampServerStart, error) {
@@ -130,7 +143,7 @@ func (b RequestTwSession) Encode(c TwampSessionConfig) {
 	b[command] = byte(5)
 	b[ipVersion] = byte(4) // As per RFC, this value can be 4 (IPv4) or 6 (IPv6).
 	binary.BigEndian.PutUint16(b[senderPort:], uint16(c.SenderPort))
-	binary.BigEndian.PutUint16(b[receiverPort:], uint16(c.Port))
+	binary.BigEndian.PutUint16(b[receiverPort:], uint16(c.ReceiverPort))
 	binary.BigEndian.PutUint32(b[paddingLength:], uint32(c.Padding))
 	binary.BigEndian.PutUint32(b[startTime:], start_time.Integer)
 	binary.BigEndian.PutUint32(b[startTime+4:], start_time.Fraction)

--- a/connection.go
+++ b/connection.go
@@ -33,7 +33,7 @@ func (c *TwampConnection) RemoteAddr() net.Addr {
 }
 
 /*
-	TWAMP client session negotiation message.
+TWAMP client session negotiation message.
 */
 type TwampClientSetUpResponse struct {
 	Mode     uint32
@@ -43,7 +43,7 @@ type TwampClientSetUpResponse struct {
 }
 
 /*
-	TWAMP server greeting message.
+TWAMP server greeting message.
 */
 type TwampServerGreeting struct {
 	Mode      uint32   // modes (4 bytes)
@@ -85,10 +85,11 @@ type TwampServerStart struct {
 }
 
 type TwampSessionConfig struct {
-	Port    int
-	Padding int
-	Timeout int
-	TOS     int
+	Port       int
+	SenderPort int
+	Padding    int
+	Timeout    int
+	TOS        int
 }
 
 func (c *TwampConnection) getTwampServerStartMessage() (*TwampServerStart, error) {
@@ -113,6 +114,7 @@ func (c *TwampConnection) getTwampServerStartMessage() (*TwampServerStart, error
 /* Byte offsets for Request-TW-Session TWAMP PDU */
 const (
 	command         = 0
+	ipVersion       = 1
 	senderPort      = 12
 	receiverPort    = 14
 	paddingLength   = 64
@@ -126,7 +128,8 @@ type RequestTwSession []byte
 func (b RequestTwSession) Encode(c TwampSessionConfig) {
 	start_time := NewTwampTimestamp(time.Now())
 	b[command] = byte(5)
-	binary.BigEndian.PutUint16(b[senderPort:], 6666)
+	b[ipVersion] = byte(4) // As per RFC, this value can be 4 (IPv4) or 6 (IPv6).
+	binary.BigEndian.PutUint16(b[senderPort:], uint16(c.SenderPort))
 	binary.BigEndian.PutUint16(b[receiverPort:], uint16(c.Port))
 	binary.BigEndian.PutUint32(b[paddingLength:], uint32(c.Padding))
 	binary.BigEndian.PutUint32(b[startTime:], start_time.Integer)

--- a/connection.go
+++ b/connection.go
@@ -88,21 +88,21 @@ type TwampSessionConfig struct {
 	// According to RFC 4656, if Conf-Receiver is not set, Receiver Port
 	// is the UDP port OWAMP-Test to which packets are
 	// requested to be sent.
-	ReceiverPort	int
+	ReceiverPort int
 	// According to RFC 4656, if Conf-Sender is not set, Sender Port is the
 	// UDP port from which OWAMP-Test packets will be sent.
-	SenderPort 		int
+	SenderPort int
 	// According to RFC 4656, Padding length is the number of octets to be
 	// appended to the normal OWAMP-Test packet (see more on
 	// padding in discussion of OWAMP-Test).
-	Padding    		int
+	Padding int
 	// According to RFC 4656, Timeout (or a loss threshold) is an interval of time
 	// (expressed as a timestamp). A packet belonging to the test session
 	// that is being set up by the current Request-Session command will
 	// be considered lost if it is not received during Timeout seconds
 	// after it is sent.
-	Timeout    		int
-	TOS        		int
+	Timeout int
+	TOS     int
 }
 
 func (c *TwampConnection) getTwampServerStartMessage() (*TwampServerStart, error) {
@@ -125,31 +125,31 @@ func (c *TwampConnection) getTwampServerStartMessage() (*TwampServerStart, error
 }
 
 /* Byte offsets for Request-TW-Session TWAMP PDU */
-const (
-	command         = 0
-	ipVersion       = 1
-	senderPort      = 12
-	receiverPort    = 14
-	paddingLength   = 64
-	startTime       = 68
-	timeout         = 76
-	typePDescriptor = 84
+const (	// TODO these constants should be removed as part of a refactor when control changel messages are refactored to use "struct based" messaging which is clearer
+	offsetRequestTwampSessionCommand         = 0
+	offsetRequestTwampSessionIpVersion       = 1
+	offsetRequestTwampSessionSenderPort      = 12
+	offsetRequestTwampSessionReceiverPort    = 14
+	offsetRequestTwampSessionPaddingLength   = 64
+	offsetRequestTwampSessionStartTime       = 68
+	offsetRequestTwampSessionTimeout         = 76
+	offsetRequestTwampSessionTypePDescriptor = 84
 )
 
 type RequestTwSession []byte
 
 func (b RequestTwSession) Encode(c TwampSessionConfig) {
 	start_time := NewTwampTimestamp(time.Now())
-	b[command] = byte(5)
-	b[ipVersion] = byte(4) // As per RFC, this value can be 4 (IPv4) or 6 (IPv6).
-	binary.BigEndian.PutUint16(b[senderPort:], uint16(c.SenderPort))
-	binary.BigEndian.PutUint16(b[receiverPort:], uint16(c.ReceiverPort))
-	binary.BigEndian.PutUint32(b[paddingLength:], uint32(c.Padding))
-	binary.BigEndian.PutUint32(b[startTime:], start_time.Integer)
-	binary.BigEndian.PutUint32(b[startTime+4:], start_time.Fraction)
-	binary.BigEndian.PutUint32(b[timeout:], uint32(c.Timeout))
-	binary.BigEndian.PutUint32(b[timeout+4:], 0)
-	binary.BigEndian.PutUint32(b[typePDescriptor:], uint32(c.TOS))
+	b[offsetRequestTwampSessionCommand] = byte(5)
+	b[offsetRequestTwampSessionIpVersion] = byte(4) // As per RFC, this value can be 4 (IPv4) or 6 (IPv6).
+	binary.BigEndian.PutUint16(b[offsetRequestTwampSessionSenderPort:], uint16(c.SenderPort))
+	binary.BigEndian.PutUint16(b[offsetRequestTwampSessionReceiverPort:], uint16(c.ReceiverPort))
+	binary.BigEndian.PutUint32(b[offsetRequestTwampSessionPaddingLength:], uint32(c.Padding))
+	binary.BigEndian.PutUint32(b[offsetRequestTwampSessionStartTime:], start_time.Integer)
+	binary.BigEndian.PutUint32(b[offsetRequestTwampSessionStartTime+4:], start_time.Fraction)
+	binary.BigEndian.PutUint32(b[offsetRequestTwampSessionTimeout:], uint32(c.Timeout))
+	binary.BigEndian.PutUint32(b[offsetRequestTwampSessionTimeout+4:], 0)
+	binary.BigEndian.PutUint32(b[offsetRequestTwampSessionTypePDescriptor:], uint32(c.TOS))
 }
 
 func (c *TwampConnection) CreateSession(config TwampSessionConfig) (*TwampSession, error) {

--- a/session.go
+++ b/session.go
@@ -77,7 +77,7 @@ func (s *TwampSession) CreateTest() (*TwampTest, error) {
 	if err != nil {
 		return nil, err
 	}
-	localAddress := fmt.Sprintf("%s:%d", test.GetLocalTestHost(), s.GetConfig().Port)
+	localAddress := fmt.Sprintf("%s:%d", test.GetLocalTestHost(), s.GetConfig().ReceiverPort)
 	localAddr, err := net.ResolveUDPAddr("udp", localAddress)
 	if err != nil {
 		return nil, err

--- a/session.go
+++ b/session.go
@@ -84,12 +84,11 @@ func (s *TwampSession) CreateTest() (*TwampTest, error) {
 	}
 
 	conn, err := net.DialUDP("udp", localAddr, remoteAddr)
-	test.SetConnection(conn)
-
 	if err != nil {
-		log.Printf("Some error %+v", err)
 		return nil, err
 	}
+
+	test.SetConnection(conn)
 
 	return test, nil
 }

--- a/test.go
+++ b/test.go
@@ -177,6 +177,14 @@ func (t *TwampTest) FormatJSON(r *PingResults) {
 	fmt.Printf("%s\n", string(doc))
 }
 
+func (t *TwampTest) ReturnJSON(r *PingResults) string {
+	doc, err := json.Marshal(r)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return fmt.Sprintf("%s\n", string(doc))
+}
+
 func (t *TwampTest) Ping(count int, isRapid bool, interval int) *PingResults {
 	Stats := &PingResultStats{}
 	Results := &PingResults{Stat: Stats}

--- a/test.go
+++ b/test.go
@@ -14,7 +14,7 @@ import (
 )
 
 /*
-	TWAMP test connection used for running TWAMP tests.
+TWAMP test connection used for running TWAMP tests.
 */
 type TwampTest struct {
 	session *TwampSession
@@ -23,7 +23,6 @@ type TwampTest struct {
 }
 
 /*
-
  */
 func (t *TwampTest) SetConnection(conn *net.UDPConn) {
 	c := ipv4.NewConn(conn)
@@ -43,21 +42,21 @@ func (t *TwampTest) SetConnection(conn *net.UDPConn) {
 }
 
 /*
-	Get TWAMP Test UDP connection.
+Get TWAMP Test UDP connection.
 */
 func (t *TwampTest) GetConnection() *net.UDPConn {
 	return t.conn
 }
 
 /*
-	Get the underlying TWAMP control session for the TWAMP test.
+Get the underlying TWAMP control session for the TWAMP test.
 */
 func (t *TwampTest) GetSession() *TwampSession {
 	return t.session
 }
 
 /*
-	Get the remote TWAMP IP/UDP address.
+Get the remote TWAMP IP/UDP address.
 */
 func (t *TwampTest) RemoteAddr() (*net.UDPAddr, error) {
 	address := fmt.Sprintf("%s:%d", t.GetRemoteTestHost(), t.GetRemoteTestPort())
@@ -65,14 +64,14 @@ func (t *TwampTest) RemoteAddr() (*net.UDPAddr, error) {
 }
 
 /*
-	Get the remote TWAMP UDP port number.
+Get the remote TWAMP UDP port number.
 */
 func (t *TwampTest) GetRemoteTestPort() uint16 {
 	return t.GetSession().port
 }
 
 /*
-	Get the local IP address for the TWAMP control session.
+Get the local IP address for the TWAMP control session.
 */
 func (t *TwampTest) GetLocalTestHost() string {
 	localAddress := t.session.GetConnection().LocalAddr()
@@ -80,7 +79,7 @@ func (t *TwampTest) GetLocalTestHost() string {
 }
 
 /*
-	Get the remote IP address for the TWAMP control session.
+Get the remote IP address for the TWAMP control session.
 */
 func (t *TwampTest) GetRemoteTestHost() string {
 	remoteAddress := t.session.GetConnection().RemoteAddr()
@@ -88,7 +87,7 @@ func (t *TwampTest) GetRemoteTestHost() string {
 }
 
 /*
-	Run a TWAMP test and return a pointer to the TwampResults.
+Run a TWAMP test and return a pointer to the TwampResults.
 */
 func (t *TwampTest) Run() (*TwampResults, error) {
 
@@ -99,7 +98,6 @@ func (t *TwampTest) Run() (*TwampResults, error) {
 	// receive test packets
 	buffer, err := readFromSocket(t.GetConnection(), 64)
 	if err != nil {
-		//		log.Printf("Read error: %s\n", err)
 		return nil, err
 	}
 
@@ -283,6 +281,7 @@ func (t *TwampTest) RunX(count int) *PingResults {
 			TotalRTT += results.GetRTT()
 			Stats.Received++
 			Results.Results = append(Results.Results, results)
+			log.Println("%+v", results)
 		}
 	}
 

--- a/test.go
+++ b/test.go
@@ -1,6 +1,7 @@
 package twamp
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"unsafe"
 )
 
 /*
@@ -21,6 +23,12 @@ type TwampTest struct {
 	conn    *net.UDPConn
 	seq     uint32
 }
+
+/*
+Function header called when a test package arrived back.
+Can be used to show some progress
+ */
+type TwampTestCallbackFunction func(result *TwampResults);
 
 /*
  */
@@ -86,50 +94,67 @@ func (t *TwampTest) GetRemoteTestHost() string {
 	return strings.Split(remoteAddress.String(), ":")[0]
 }
 
+type MeasurementPacket struct {
+	Sequence uint32
+	Timestamp TwampTimestamp
+	ErrorEstimate uint16
+	MBZ uint16
+	ReceiveTimeStamp TwampTimestamp
+	SenderSequence uint32
+	SenderTimeStamp TwampTimestamp
+	SenderErrorEstimate uint16
+	Mbz uint16
+	SenderTtl byte
+	//Padding []byte
+}
+
 /*
 Run a TWAMP test and return a pointer to the TwampResults.
 */
 func (t *TwampTest) Run() (*TwampResults, error) {
-
+	paddingSize := t.GetSession().config.Padding
 	senderSeqNum := t.seq
 
-	size := t.sendTestMessage(false)
+	size := t.sendTestMessage(true)
 
-	// receive test packets
-	buffer, err := readFromSocket(t.GetConnection(), 64)
+	// receive test packets - allocate a receive buffer of a size we expect to receive plus a bit to know if we get some garbage
+	buffer, err := readFromSocket(t.GetConnection(), (int(unsafe.Sizeof(MeasurementPacket{}))+paddingSize)*2)
 	if err != nil {
 		return nil, err
 	}
 
 	finished := time.Now()
 
+	responseHeader := MeasurementPacket{}
+	err = binary.Read(&buffer, binary.BigEndian, &responseHeader)
+	if err != nil {
+		log.Fatalf("Failed to deserialize measurement package. %v", err)
+	}
+
+	responsePadding := make([]byte, paddingSize, paddingSize)
+	receivedPaddignSize, err := buffer.Read(responsePadding)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("Error when receivin padding. %v\n", err))
+	}
+
+	if receivedPaddignSize != paddingSize {
+		return nil, errors.New(fmt.Sprintf("Incorrect padding. Expected padding size was %d but received %d.\n", paddingSize, receivedPaddignSize))
+	}
+
 	// process test results
 	r := &TwampResults{}
 	r.SenderSize = size
-	r.SeqNum = binary.BigEndian.Uint32(buffer.Next(4))
-
-	r.Timestamp = NewTimestamp(
-		binary.BigEndian.Uint32(buffer.Next(4)),
-		binary.BigEndian.Uint32(buffer.Next(4)),
-	)
-
-	r.ErrorEstimate = binary.BigEndian.Uint16(buffer.Next(2))
-	_ = buffer.Next(2)
-	r.ReceiveTimestamp = NewTimestamp(
-		binary.BigEndian.Uint32(buffer.Next(4)),
-		binary.BigEndian.Uint32(buffer.Next(4)),
-	)
-	r.SenderSeqNum = binary.BigEndian.Uint32(buffer.Next(4))
-	r.SenderTimestamp = NewTimestamp(
-		binary.BigEndian.Uint32(buffer.Next(4)),
-		binary.BigEndian.Uint32(buffer.Next(4)),
-	)
-	r.SenderErrorEstimate = binary.BigEndian.Uint16(buffer.Next(2))
-	_ = buffer.Next(2)
-	r.SenderTTL = byte(buffer.Next(1)[0])
+	r.SeqNum = responseHeader.Sequence
+	r.Timestamp = NewTimestamp(responseHeader.Timestamp)
+	r.ErrorEstimate = responseHeader.ErrorEstimate
+	r.ReceiveTimestamp = NewTimestamp(responseHeader.ReceiveTimeStamp)
+	r.SenderSeqNum = responseHeader.SenderSequence
+	r.SenderTimestamp = NewTimestamp(responseHeader.SenderTimeStamp)
+	r.SenderErrorEstimate = responseHeader.SenderErrorEstimate
+	r.SenderTTL = responseHeader.SenderTtl
 	r.FinishedTimestamp = finished
 
-	if senderSeqNum != r.SeqNum {
+	if senderSeqNum != r.SenderSeqNum {
 		return nil, errors.New(
 			fmt.Sprintf("Expected seq # %d but received %d.\n", senderSeqNum, r.SeqNum),
 		)
@@ -139,28 +164,47 @@ func (t *TwampTest) Run() (*TwampResults, error) {
 }
 
 func (t *TwampTest) sendTestMessage(use_all_zeroes bool) int {
-	now := NewTwampTimestamp(time.Now())
-	totalSize := 14 + int(t.GetSession().config.Padding)
-	var pdu []byte = make([]byte, totalSize)
-
-	binary.BigEndian.PutUint32(pdu[0:], t.seq)        // sequence number
-	binary.BigEndian.PutUint32(pdu[4:], now.Integer)  // timestamp (integer)
-	binary.BigEndian.PutUint32(pdu[8:], now.Fraction) // timestamp (fraction)
-	pdu[12] = byte(1)                                 // Synchronized, MBZ, Scale
-	pdu[13] = byte(1)                                 // multiplier
+	packetHeader := MeasurementPacket{
+		Sequence:            t.seq,
+		Timestamp:           *NewTwampTimestamp(time.Now()),
+		ErrorEstimate:       0x0101,
+		MBZ:                 0x0000,
+		ReceiveTimeStamp:    TwampTimestamp{},
+		SenderSequence:      0,
+		SenderTimeStamp:     TwampTimestamp{},
+		SenderErrorEstimate: 0x0000,
+		Mbz:                 0x0000,
+		SenderTtl:           87,
+	}
 
 	// seed psuedo-random number generator if requested
 	if !use_all_zeroes {
 		rand.NewSource(int64(time.Now().Unix()))
 	}
 
-	for x := 14; x < totalSize; x++ {
+	paddingSize := t.GetSession().config.Padding
+	padding := make([]byte, paddingSize, paddingSize)
+
+	for x := 0; x < paddingSize; x++ {
 		if use_all_zeroes {
-			pdu[x] = 0
+			padding[x] = 0
 		} else {
-			pdu[x] = byte(rand.Intn(255))
+			padding[x] = byte(rand.Intn(255))
 		}
 	}
+
+	var binaryBuffer bytes.Buffer
+	err := binary.Write(&binaryBuffer, binary.BigEndian, packetHeader)
+	if err != nil {
+		log.Fatalf("Failed to serialize measurement package. %v", err)
+	}
+
+	headerBytes := binaryBuffer.Bytes()
+	headerSize := binaryBuffer.Len()
+	totalSize := headerSize+paddingSize
+	var pdu []byte = make([]byte, totalSize)
+	copy(pdu[0:], headerBytes)
+	copy(pdu[headerSize:], padding)
 
 	t.GetConnection().Write(pdu)
 	t.seq++
@@ -196,6 +240,7 @@ func (t *TwampTest) Ping(count int, isRapid bool, interval int) *PingResults {
 		Stats.Transmitted++
 		results, err := t.Run()
 		if err != nil {
+			// TODO Do we need error logging here? I guess not because dot represents the sort error message here but should be double checked.
 			if isRapid {
 				fmt.Printf(".")
 			}
@@ -257,7 +302,7 @@ func (t *TwampTest) Ping(count int, isRapid bool, interval int) *PingResults {
 	return Results
 }
 
-func (t *TwampTest) RunX(count int) *PingResults {
+func (t *TwampTest) RunX(count int, callback TwampTestCallbackFunction) *PingResults {
 	Stats := &PingResultStats{}
 	Results := &PingResults{Stat: Stats}
 	var TotalRTT time.Duration = 0
@@ -266,6 +311,7 @@ func (t *TwampTest) RunX(count int) *PingResults {
 		Stats.Transmitted++
 		results, err := t.Run()
 		if err != nil {
+			log.Printf("%v\n", err)
 		} else {
 			if i == 0 {
 				Stats.Min = results.GetRTT()
@@ -281,7 +327,9 @@ func (t *TwampTest) RunX(count int) *PingResults {
 			TotalRTT += results.GetRTT()
 			Stats.Received++
 			Results.Results = append(Results.Results, results)
-			log.Println("%+v", results)
+			if callback != nil {
+				callback(results)
+			}
 		}
 	}
 

--- a/test.go
+++ b/test.go
@@ -254,6 +254,7 @@ func (t *TwampTest) Ping(count int, isRapid bool, interval int) *PingResults {
 		(float64(Stats.Max) / float64(time.Millisecond)),
 		(float64(Stats.StdDev) / float64(time.Millisecond)),
 	)
+	defer t.conn.Close()
 
 	return Results
 }
@@ -288,6 +289,7 @@ func (t *TwampTest) RunX(count int) *PingResults {
 	Stats.Avg = time.Duration(int64(TotalRTT) / int64(count))
 	Stats.Loss = float64(float64(Stats.Transmitted-Stats.Received)/float64(Stats.Transmitted)) * 100.0
 	Stats.StdDev = Results.stdDev(Stats.Avg)
+	defer t.conn.Close()
 
 	return Results
 }

--- a/timestamp.go
+++ b/timestamp.go
@@ -21,8 +21,8 @@ func NewTwampTimestamp(t time.Time) *TwampTimestamp {
 	}
 }
 
-func NewTimestamp(sec uint32, nsec uint32) time.Time {
-	t := time.Unix(int64(sec), int64(nsec))
+func NewTimestamp(twampTimestamp TwampTimestamp) time.Time {
+	t := time.Unix(int64(twampTimestamp.Integer), int64(twampTimestamp.Fraction))
 	t = t.AddDate(-70, 0, 0) // convert epoch from 1970 to 1900 per RFC 1305
 	return t
 }


### PR DESCRIPTION
**Note**

First of all, thanks for your work! It was a great base for my work!

**Content**

I found number of TODOs in the code to make it work. I fixed them. Please check commits for details but in a nutshell:
- `IP Version` field was filled with zero in the `Request Session` message. It can be 4 or 6 only.
- Measurement package was handled incorrectly. I refactored to use golang structs to make it clearer.
- `TwampSessionConfig` struct is now easier to understand regarding the ports and a hardcoded part number is also replaced to use this config struct instead.
- Error handling fixes
- Comments added

**Backlog**

It would be still nice to refactor the TWAMP control channel massaging to use golang struct types instead of math with byte offsets same way as I implemented with the actual measurement message types.