### PR TITLE
Fix to use SenderPort as source port for testing

### DIFF
--- a/session.go
+++ b/session.go
@@ -85,7 +85,7 @@ func (s *TwampSession) CreateTest() (*TwampTest, error) {
 	if err != nil {
 		return nil, err
 	}
-	localAddress := fmt.Sprintf("%s:%d", test.GetLocalTestHost(), s.GetConfig().ReceiverPort)
+	localAddress := fmt.Sprintf("%s:%d", test.GetLocalTestHost(), s.GetConfig().SenderPort)
 	localAddr, err := net.ResolveUDPAddr("udp", localAddress)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
SenderPort is present in TwampSessionConfig as the source port setting for test packets, but the current implementation uses RecieverPort for it.

It should be modified to use SenderPort as the source port.