### PR TITLE
Don't panic

### DIFF
--- a/session.go
+++ b/session.go
@@ -96,7 +96,9 @@ func (s *TwampSession) CreateTest() (*TwampTest, error) {
 		return nil, err
 	}
 
-	test.SetConnection(conn)
+	if err := test.SetConnection(conn); err != nil {
+		return nil, err
+	}
 
 	return test, nil
 }

--- a/test.go
+++ b/test.go
@@ -568,12 +568,15 @@ func (t *TwampTest) RunMultiple(count uint64, callback TwampTestCallbackFunction
 	// Calculate totals upon returning
 	defer func() {
 		t.mutex.RLock()
-		stats.Avg = time.Duration(uint64(totalRTT) / stats.Transmitted)
+		if stats.Transmitted > 0 {
+			stats.Avg = time.Duration(uint64(totalRTT) / stats.Transmitted)
+		}
 		stats.Loss = float64(float64(stats.Transmitted-stats.Received)/float64(stats.Transmitted)) * 100.0
-		stats.StdDev = pingResults.stdDev(stats.Avg)
+		if len(pingResults.Results) > 1 {
+			stats.StdDev = pingResults.stdDev(stats.Avg)
+		}
 		t.mutex.RUnlock()
 	}()
-
 
 	// We must use a struct chan instead of a struct pointer chan to
 	// make sure that we have a snapshot of the reply received, in case

--- a/test.go
+++ b/test.go
@@ -35,21 +35,22 @@ type TwampTestCallbackFunction func(result *TwampResults);
 
 /*
  */
-func (t *TwampTest) SetConnection(conn *net.UDPConn) {
+func (t *TwampTest) SetConnection(conn *net.UDPConn) error {
 	c := ipv4.NewConn(conn)
 
 	// RFC recommends IP TTL of 255
 	err := c.SetTTL(255)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("setting TTL: %w", err)
 	}
 
 	err = c.SetTOS(t.GetSession().GetConfig().TOS)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("setting TOS: %w", err)
 	}
 
 	t.conn = conn
+	return nil
 }
 
 /*
@@ -95,7 +96,9 @@ func (t *TwampTest) Reset() error {
 	if err != nil {
 		return err
 	}
-	t.SetConnection(conn)
+	if err := t.SetConnection(conn); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Avoid panicking in the library (as opposed to the command-line tool provided with the library). Otherwise the library can make processes using it crash.