### PR TITLE
Fix mode handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package twamp
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -13,8 +14,6 @@ import (
 const (
 	ModeUnspecified     = 0
 	ModeUnauthenticated = 1
-	ModeAuthenticated   = 2
-	ModeEncypted        = 4
 )
 
 type TwampClient struct{}
@@ -39,15 +38,12 @@ func (c *TwampClient) Connect(hostname string) (*TwampConnection, error) {
 		return nil, err
 	}
 
-	// check greeting mode for errors
-	switch greeting.Mode {
-	case ModeUnspecified:
+	if greeting.Mode == ModeUnspecified {
 		return nil, fmt.Errorf("The TWAMP server is not interested in communicating with you.")
-	case ModeUnauthenticated:
-	case ModeAuthenticated:
-		return nil, fmt.Errorf("Authentication is not currently supported.")
-	case ModeEncypted:
-		return nil, fmt.Errorf("Encyption is not currently supported.")
+	}
+
+	if greeting.Mode&ModeUnauthenticated == 0 {
+		return nil, errors.New("only unauthenticated mode is currently supported")
 	}
 
 	// negotiate TWAMP session configuration


### PR DESCRIPTION
The final bit of the byte used to encode the mode indicates whether the reflector is willing to accept using the unauthenticated mode. Since the library only supports the unauthenticated mode, we need to check that the final bit is set to 1, as opposed to checking that the byte is equal to 1. Otherwise, since we're already checking for the unspecified mode (0), we can report an error if the final bit is not set to 1.