### PR TITLE
Use random padding by default

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -141,7 +141,7 @@ type TwampSessionConfig struct {
 	// after it is sent.
 	Timeout int
 	TOS     int
-	// According to RFC 4656, the padding should be pseudo-random and generated
+	// According to RFC 5357, the padding should be pseudo-random and generated
 	// independently of other pseudo-random numbers by default, and
 	// implementations must provide a way of making the padding consist of all
 	// zeros.

--- a/connection.go
+++ b/connection.go
@@ -141,6 +141,11 @@ type TwampSessionConfig struct {
 	// after it is sent.
 	Timeout int
 	TOS     int
+	// According to RFC 4656, the padding should be pseudo-random and generated
+	// independently of other pseudo-random numbers by default, and
+	// implementations must provide a way of making the padding consist of all
+	// zeros.
+	ZeroPad bool
 }
 
 func (c *TwampConnection) getTwampServerStartMessage() (*TwampServerStart, error) {

--- a/test.go
+++ b/test.go
@@ -383,7 +383,7 @@ func (t *TwampTest) putMessageOnWire(padZero bool) (int, byte, time.Time, error)
 	// of a []byte happens to be a slice filled with zeros.
 	if !t.GetSession().GetConfig().ZeroPad {
 		if _, err := cRand.Read(padding); err != nil {
-			log.Fatalf("generating random padding: %s", err)
+			return 0, 0, time.Time{}, fmt.Errorf("generating random padding: %w", err)
 		}
 	}
 

--- a/test.go
+++ b/test.go
@@ -2,6 +2,7 @@ package twamp
 
 import (
 	"bytes"
+	cRand "crypto/rand"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -361,6 +362,14 @@ func (t *TwampTest) putMessageOnWire(padZero bool) (int, byte, time.Time) {
 
 	paddingSize := t.GetSession().config.Padding
 	padding := make([]byte, paddingSize, paddingSize)
+
+	// Note that Go initializes variables with zero-values, which in the case
+	// of a []byte happens to be a slice filled with zeros.
+	if !t.GetSession().GetConfig().ZeroPad {
+		if _, err := cRand.Read(padding); err != nil {
+			log.Fatalf("generating random padding: %s", err)
+		}
+	}
 
 	for x := 0; x < paddingSize; x++ {
 		padding[x] = padder()

--- a/test.go
+++ b/test.go
@@ -367,15 +367,6 @@ func (t *TwampTest) putMessageOnWire(padZero bool) (int, byte, time.Time, error)
 		SenderTtl:           ttl,
 	}
 
-	// seed psuedo-random number generator if requested
-	var padder func() byte
-	if !padZero {
-		rand.NewSource(int64(time.Now().Unix()))
-		padder = func() byte { return byte(rand.Intn(255)) }
-	} else {
-		padder = func() byte { return 0 }
-	}
-
 	paddingSize := t.GetSession().config.Padding
 	padding := make([]byte, paddingSize, paddingSize)
 
@@ -385,10 +376,6 @@ func (t *TwampTest) putMessageOnWire(padZero bool) (int, byte, time.Time, error)
 		if _, err := cRand.Read(padding); err != nil {
 			return 0, 0, time.Time{}, fmt.Errorf("generating random padding: %w", err)
 		}
-	}
-
-	for x := 0; x < paddingSize; x++ {
-		padding[x] = padder()
 	}
 
 	var binaryBuffer bytes.Buffer

--- a/test.go
+++ b/test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"golang.org/x/net/ipv4"
 	"log"
-	"math/rand"
 	"net"
 	"strings"
 	"sync"


### PR DESCRIPTION
From RFC 5357:

> Packet Padding in TWAMP-Test SHOULD be pseudo-random (it MUST be
> generated independently of any other pseudo-random numbers mentioned
> in this document).  However, implementations MUST provide a
> configuration parameter, an option, or a different means of making
> Packet Padding consist of all zeros.
