### PR TITLE
Enable closing UDP sockets

### DIFF
--- a/test.go
+++ b/test.go
@@ -33,8 +33,10 @@ Can be used to show some progress
 */
 type TwampTestCallbackFunction func(result *TwampResults)
 
-/*
- */
+func (t *TwampTest) CloseUDP() error {
+	return t.conn.Close()
+}
+
 func (t *TwampTest) SetConnection(conn *net.UDPConn) error {
 	c := ipv4.NewConn(conn)
 


### PR DESCRIPTION
Long-running processes using this library must be able to close UDP sockets if needed. For instance, if the reflector goes down, we want to be able to reclaim the UDP socket without restarting the process.