### PR TITLE
Use exact buffer size for packet

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,7 +70,11 @@ func readFromSocket(conn net.Conn, size int, timeoutSeconds int) (bytes.Buffer, 
 	conn.SetReadDeadline(timeout)
 	bytesRead, err := conn.Read(buf)
 
-	if err != nil && bytesRead < size {
+	if err != nil {
+		return buffer, err
+	}
+
+	if bytesRead < size {
 		return buffer, fmt.Errorf(fmt.Sprintf("readFromSocket: expected %d bytes, got %d", size, bytesRead))
 	}
 


### PR DESCRIPTION
We know from the protocol exactly how big measurement packets are. We can therefore use a buffer of exactly the right size. This allows us to distinguish between different error situations, such as the reflector not sending enough bytes, a timeout, and others.